### PR TITLE
Deprecate old fields

### DIFF
--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -97,18 +97,14 @@ func (c *Client) wordCount() int {
 }
 
 func (c *Client) relayURL() internal.SimpleURL {
-	if c.TransitRelayAddress != "" {
-		relayUrl, err := internal.NewSimpleURL(c.TransitRelayAddress)
-		if err != nil {
-			return relayUrl
-		} else {
-			errors.New("Malformed Transit Relay Address")
-		}
-	}
-	if c.TransitRelayURL != "" {
+	switch {
+	case c.TransitRelayAddress != "":
+		return internal.MustNewSimpleURL(c.TransitRelayAddress)
+	case c.TransitRelayURL != "":
 		return internal.MustNewSimpleURL(c.TransitRelayURL)
+	default:
+		return internal.MustNewSimpleURL(DefaultTransitRelayURL)
 	}
-	return internal.MustNewSimpleURL(DefaultTransitRelayURL)
 }
 
 // SendResult has information about whether or not a Send command was successful.

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -33,6 +33,10 @@ type Client struct {
 	// DefaultRendezvousURL will be used.
 	RendezvousURL string
 
+	// Deprecated: TransitRelayAddress is no longer used,
+	// instead, the new field TransitRelayURL is used.
+	TransitRelayAddress string
+
 	// TransitRelayURL is the proto:host:port address to offer
 	// to use for file transfers where direct connections are unavailable.
 	// If empty, DefaultTransitRelayURL will be used.
@@ -63,7 +67,10 @@ var (
 	// DefaultRendezvousURL is the default Rendezvous server to use.
 	DefaultRendezvousURL = "ws://relay.magic-wormhole.io:4000/v1"
 
-	// DefaultTransitRelayURL is the default transit server to ues.
+	// Deprecated: New code should use DefaultTransitRelayURL.
+	DefaultTransitRelayAddress = ""
+
+	// DefaultTransitRelayURL is the default transit server to use.
 	DefaultTransitRelayURL = "tcp:transit.magic-wormhole.io:4001"
 )
 
@@ -90,6 +97,14 @@ func (c *Client) wordCount() int {
 }
 
 func (c *Client) relayURL() internal.SimpleURL {
+	if c.TransitRelayAddress != "" {
+		relayUrl, err := internal.NewSimpleURL(c.TransitRelayAddress)
+		if err != nil {
+			return relayUrl
+		} else {
+			errors.New("Malformed Transit Relay Address")
+		}
+	}
 	if c.TransitRelayURL != "" {
 		return internal.MustNewSimpleURL(c.TransitRelayURL)
 	}

--- a/wormhole/wormhole_test.go
+++ b/wormhole/wormhole_test.go
@@ -754,8 +754,7 @@ func TestClient_relayURL_default(t *testing.T) {
 	}
 }
 
-// if TransitRelayAddress is set, then it is used instead of
-// TransitRelayURL
+// if TransitRelayAddress is set, then it is used instead of TransitRelayURL
 func TestClient_relayURL_relayAddress(t *testing.T) {
 	var c Client
 

--- a/wormhole/wormhole_test.go
+++ b/wormhole/wormhole_test.go
@@ -754,6 +754,25 @@ func TestClient_relayURL_default(t *testing.T) {
 	}
 }
 
+// if TransitRelayAddress is set, then it is used instead of
+// TransitRelayURL
+func TestClient_relayURL_relayAddress(t *testing.T) {
+	var c Client
+
+	// transitRelayAddress is in host:port format
+	// protocol is assumed as "tcp".
+	c.TransitRelayAddress = "transit.magic-wormhole.io:4001"
+
+	// if proto field is empty in the input string, then
+	// relayURL() would deduce it as "tcp".
+	url := c.relayURL()
+
+	expectedProto := "tcp"
+	if url.Proto != expectedProto {
+		t.Error(fmt.Sprintf("invalid protocol, expected %v, got %v", expectedProto, url.Proto))
+	}
+}
+
 func TestWormholeFileTransportSendRecvViaWSRelayServer(t *testing.T) {
 	ctx := context.Background()
 

--- a/wormhole/wormhole_test.go
+++ b/wormhole/wormhole_test.go
@@ -751,7 +751,7 @@ func TestClient_relayURL_default(t *testing.T) {
 
 	expectedProto := "tcp"
 	expectedHost := "transit.magic-wormhole.io"
-	expectedPort := "8001"
+	expectedPort := "4001"
 
 	DefaultTransitRelayURL = strings.Join([]string{expectedProto, expectedHost, expectedPort}, ":")
 	url := c.relayURL()


### PR DESCRIPTION
Reintroduce deleted fields and instead deprecate them with the godoc deprecation conventions. If the deprecated `TransitRelayAddress` is set, then it is used. If not, `TransitRelayURL` is used.