### PR TITLE
Client#SendFile and Client#Receive signatures changed

### DIFF
--- a/wasm/client.go
+++ b/wasm/client.go
@@ -226,7 +226,7 @@ func Client_SendFile(_ js.Value, args []js.Value) interface{} {
 			opts = collectTransferOptions(args[3])
 		}
 
-		code, resultChan, err := client.SendFile(ctx, fileName, fileReader, opts...)
+		code, resultChan, err := client.SendFile(ctx, fileName, fileWrapper, true, opts...)
 		if err != nil {
 			reject(err)
 			return
@@ -325,7 +325,7 @@ func Client_RecvFile(_ js.Value, args []js.Value) interface{} {
 			opts = collectTransferOptions(args[2])
 		}
 
-		msg, err := client.Receive(ctx, code, opts...)
+		msg, err := client.Receive(ctx, code, true, opts...)
 		if err != nil {
 			reject(err)
 			return


### PR DESCRIPTION
This PR updates usage of `Client#SendFile` and `Client#Receive` after their signatures were changed. This also fixes a bug where the reader variable `fileWrapper` was incorrectly being referenced as `fileReader`.

---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
