### PR TITLE
websocker Read size type is int64, not an int

### DIFF
--- a/wormhole/file_transport.go
+++ b/wormhole/file_transport.go
@@ -35,7 +35,7 @@ const (
 )
 
 // Websocket read buffer size
-const websocketReadSize int = 65536
+const websocketReadSize int64 = 65536
 
 // UnsupportedProtocolErr is used in the default case of protocol switch
 // statements to account for unexpected protocols.


### PR DESCRIPTION
Fix the type (blunder committed in #60)

---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
