### PR TITLE
Close connection on receiver cancel

### DIFF
--- a/wormhole/recv.go
+++ b/wormhole/recv.go
@@ -273,6 +273,13 @@ func (c *Client) Receive(ctx context.Context, code string, disableListener bool,
 		return nil
 	}
 
+	go func() {
+		<-ctx.Done()
+		if fr.cryptor != nil {
+			fr.cryptor.Close()
+		}
+	}()
+
 	fr.initializeTransfer = acceptAndInitialize
 	fr.rejectTransfer = reject
 


### PR DESCRIPTION
In winden, we currently handle cancelling an ongoing transfer by refreshing the page. This closes the websocket connection and the other side gets an error about the close. When a user gets this error we can notify them that the other side cancelled the transfer. Instead of refreshing, we could directly close the connection whenever the context gets cancelled.

Also changed `client.go` to ensure `cancel` is called at the end of a transfer to prevent hanging goroutines.

---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
